### PR TITLE
invalid version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "date-fns": "^1.28.5",
-    "serve": "^6.4.2"
+    "serve": "^6.4.1"
   },
   "scripts": {
     "build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "date-fns": "^1.28.5",
-    "serve": "^6.4.1"
+    "serve": "^6.4.8"
   },
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
```
$ npm i
npm ERR! code ETARGET
npm ERR! notarget No matching version found for serve@^6.4.2
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget
npm ERR! notarget It was specified as a dependency of 'rollup-starter-app'
npm ERR! notarget

npm ERR! A complete log of this run can be found in:
npm ERR!     /usr/local/cache/npm/_logs/2017-12-12T23_49_34_314Z-debug.log
```

fixes #6