### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "rollup-starter-app",
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^11.0.1",
-    "@rollup/plugin-node-resolve": "^7.0.0",
+    "@rollup/plugin-commonjs": "^17.0.0",
+    "@rollup/plugin-node-resolve": "^11.1.0",
     "npm-run-all": "^4.1.5",
-    "rollup": "^1.16.2",
-    "rollup-plugin-terser": "^5.0.0",
-    "serve": "^11.0.2"
+    "rollup": "^2.36.2",
+    "rollup-plugin-terser": "^7.0.2",
+    "serve": "^11.3.2"
   },
   "dependencies": {
-    "date-fns": "^1.30.1"
+    "date-fns": "^2.16.1"
   },
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
Closes #20

Closes #9

Closes #4

Similar to https://github.com/rollup/rollup-starter-app/pull/19, but in 2021 and without any code changes.